### PR TITLE
Fix issue of running multiple ControlNets 

### DIFF
--- a/nodes/torch_compile_controlnet.py
+++ b/nodes/torch_compile_controlnet.py
@@ -8,33 +8,25 @@ class TorchCompileLoadControlNet:
     RETURN_TYPES = ("CONTROL_NET",)
     FUNCTION = "compile"
 
+    def __init__(self):
+        self._compiled= False
+
     @classmethod
     def INPUT_TYPES(s):
-        return {
-            "required": {
-                "controlnet": ("CONTROL_NET",),
-                "backend": (["inductor", "cudagraphs"],),
-                "fullgraph": (
-                    "BOOLEAN",
-                    {"default": False, "tooltip": "Enable full graph mode"},
-                ),
-                "mode": (
-                    [
-                        "default",
-                        "max-autotune",
-                        "max-autotune-no-cudagraphs",
-                        "reduce-overhead",
-                    ],
-                    {"default": "default"},
-                ),
-            }
-        }
+        return {"required": { 
+                    "controlnet": ("CONTROL_NET",),
+                    "backend": (["inductor", "cudagraphs"],),
+                    "fullgraph": ("BOOLEAN", {"default": False, "tooltip": "Enable full graph mode"}),
+                    "mode": (["default", "max-autotune", "max-autotune-no-cudagraphs", "reduce-overhead"], {"default": "default"}),
+                }}
 
-    def compile(self, controlnet, backend: str, mode: str, fullgraph: bool):
-        controlnet.control_model = torch.compile(
-            controlnet.control_model,
-            mode=mode,
-            fullgraph=fullgraph,
-            backend=backend,
-        )
-        return (controlnet,)
+    def compile(self, controlnet, backend, mode, fullgraph):
+        if not self._compiled:
+            try:
+                controlnet.control_model = torch.compile(controlnet.control_model, mode=mode, fullgraph=fullgraph, backend=backend)
+                self._compiled = True
+            except:
+                self._compiled = False
+                raise RuntimeError("Failed to compile model")
+       
+        return (controlnet, )

--- a/nodes/torch_compile_controlnet.py
+++ b/nodes/torch_compile_controlnet.py
@@ -9,16 +9,29 @@ class TorchCompileLoadControlNet:
     FUNCTION = "compile"
 
     def __init__(self):
-        self._compiled= False
+        self._compiled = False
 
     @classmethod
     def INPUT_TYPES(s):
-        return {"required": { 
-                    "controlnet": ("CONTROL_NET",),
-                    "backend": (["inductor", "cudagraphs"],),
-                    "fullgraph": ("BOOLEAN", {"default": False, "tooltip": "Enable full graph mode"}),
-                    "mode": (["default", "max-autotune", "max-autotune-no-cudagraphs", "reduce-overhead"], {"default": "default"}),
-                }}
+        return {
+            "required": {
+                "controlnet": ("CONTROL_NET",),
+                "backend": (["inductor", "cudagraphs"],),
+                "fullgraph": (
+                    "BOOLEAN",
+                    {"default": False, "tooltip": "Enable full graph mode"},
+                ),
+                "mode": (
+                    [
+                        "default",
+                        "max-autotune",
+                        "max-autotune-no-cudagraphs",
+                        "reduce-overhead",
+                    ],
+                    {"default": "default"},
+                ),
+            }
+        }
 
     def compile(self, controlnet, backend, mode, fullgraph):
         if not self._compiled:


### PR DESCRIPTION
A bug was discovered where multiple ControlNets would not function correctly due to torch compile management.

This PR simple adds a compiled flag first proposed by [Kijai](https://github.com/kijai/ComfyUI-KJNodes/blob/c3dc82108a2a86c17094107ead61d63f8c76200e/nodes/model_optimization_nodes.py#L591) that remedies the issue.